### PR TITLE
Disable sleeping device ability during meeting + fix issue when stop and start a meeting.

### DIFF
--- a/ios/RNDemo/NativeMobileSDKBridge.m
+++ b/ios/RNDemo/NativeMobileSDKBridge.m
@@ -40,6 +40,7 @@ RCT_EXPORT_METHOD(startMeeting:(NSDictionary *)meetingInfoDict attendeeInfo:(NSD
   {
     [meetingSession.audioVideo stop];
     meetingSession = nil;
+    [NSThread sleepForTimeInterval:3.0f];
   }
 
   logger = [[ConsoleLogger alloc] initWithName:@"NativeMobileSDKBridge" level:LogLevelDEFAULT];

--- a/ios/RNDemo/NativeMobileSDKBridge.m
+++ b/ios/RNDemo/NativeMobileSDKBridge.m
@@ -36,6 +36,9 @@ RCT_EXPORT_MODULE();
 # pragma mark: Native Function
 RCT_EXPORT_METHOD(startMeeting:(NSDictionary *)meetingInfoDict attendeeInfo:(NSDictionary *)attendeeInfoDict)
 {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[UIApplication sharedApplication] setIdleTimerDisabled: YES];
+  });
   if (meetingSession != nil)
   {
     [meetingSession.audioVideo stop];
@@ -91,6 +94,9 @@ RCT_EXPORT_METHOD(startMeeting:(NSDictionary *)meetingInfoDict attendeeInfo:(NSD
 
 RCT_EXPORT_METHOD(stopMeeting)
 {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[UIApplication sharedApplication] setIdleTimerDisabled: NO];
+  });
   [meetingSession.audioVideo stop];
   meetingSession = nil;
   [self sendEventWithName:kEventOnMeetingEnd body: nil];


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/amazon-chime-react-native-demo/issues/22

*Description of changes:*
Hello Amazon team ! 

The changes below concern the iOS bridge.

**First change :**

I noticed that **the absence of callbacks** for the stop function caused **illegalState** as detailed in the issue n°22 above. So, I added a function to stop the code execution for 3 seconds when a meeting is being stopped before starting a new one.

After **multiple tests with my team**, the 3 seconds stops (before starting a meeting) solved the issue. We have not experience illegalState after this fix.

**Second change :** 

I remove the ability for the device to **go to sleep for the meeting duration.** 

Why ?

Users are not necessary touching their screen while talking to other people. We notice a bad user experience while testing where the **device would shut off in the middle of a conversation.** 

The new code disable the shot off system feature of the phone when starting a meeting and stop it when the meeting is over.

This is pretty **standard behavior** that we can find on FaceTime or other visioconferencing apps.

If you have any issue regarding the code, or questions about this PR, I would love talking with you guys to make sure everything is ok by your standards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
