### PR TITLE
Make remaining video tile state accessible from video tile added callback

### DIFF
--- a/android/app/src/main/java/com/amazonaws/services/chime/rndemo/RNEventEmitter.kt
+++ b/android/app/src/main/java/com/amazonaws/services/chime/rndemo/RNEventEmitter.kt
@@ -35,6 +35,10 @@ class RNEventEmitter(private val reactContext: ReactApplicationContext) {
         private const val RN_EVENT_KEY_VIDEO_TILE_ID = "tileId"
         private const val RN_EVENT_KEY_VIDEO_IS_LOCAL = "isLocal"
         private const val RN_EVENT_KEY_VIDEO_IS_SCREEN_SHARE = "isScreenShare"
+        private const val RN_EVENT_KEY_VIDEO_ATTENDEE_ID = "attendeeId"
+        private const val RN_EVENT_KEY_VIDEO_PAUSE_STATE = "pauseState"
+        private const val RN_EVENT_KEY_VIDEO_VIDEO_STREAM_CONTENT_HEIGHT = "videoStreamContentHeight"
+        private const val RN_EVENT_KEY_VIDEO_VIDEO_STREAM_CONTENT_WIDTH = "videoStreamContentWidth"
 
         // Additional data for data message
         private const val RN_EVENT_KEY_DATA_MESSAGE_DATA = "data"
@@ -72,6 +76,10 @@ class RNEventEmitter(private val reactContext: ReactApplicationContext) {
         map.putInt(RN_EVENT_KEY_VIDEO_TILE_ID, tileState.tileId)
         map.putBoolean(RN_EVENT_KEY_VIDEO_IS_LOCAL, tileState.isLocalTile)
         map.putBoolean(RN_EVENT_KEY_VIDEO_IS_SCREEN_SHARE, tileState.isContent)
+        map.putString(RN_EVENT_KEY_VIDEO_ATTENDEE_ID, tileState.attendeeId)
+        map.putInt(RN_EVENT_KEY_VIDEO_PAUSE_STATE, tileState.pauseState.ordinal)
+        map.putInt(RN_EVENT_KEY_VIDEO_VIDEO_STREAM_CONTENT_HEIGHT, tileState.videoStreamContentHeight)
+        map.putInt(RN_EVENT_KEY_VIDEO_VIDEO_STREAM_CONTENT_WIDTH, tileState.videoStreamContentWidth)
         sendReactNativeEvent(eventName, map)
     }
 

--- a/ios/RNDemo/MeetingObservers.m
+++ b/ios/RNDemo/MeetingObservers.m
@@ -83,7 +83,7 @@
 
 - (void)videoTileDidAddWithTileState:(VideoTileState * _Nonnull)tileState
 {
-  [_bridge sendEventWithName:kEventOnAddVideoTile body:@{@"tileId":[NSNumber numberWithInt: (int)tileState.tileId], @"isLocal":@(tileState.isLocalTile), @"isScreenShare":@(tileState.isContent)}];
+  [_bridge sendEventWithName:kEventOnAddVideoTile body:@{@"tileId":[NSNumber numberWithInt: (int)tileState.tileId], @"isLocal":@(tileState.isLocalTile), @"isScreenShare":@(tileState.isContent), @"attendeeId":tileState.attendeeId, @"pauseState":[NSNumber numberWithInt: (int)tileState.pauseState], @"videoStreamContentHeight":[NSNumber numberWithInt: (int)tileState.videoStreamContentHeight], @"videoStreamContentWidth":[NSNumber numberWithInt: (int)tileState.videoStreamContentWidth]}];
 }
 
 - (void)videoTileDidPauseWithTileState:(VideoTileState * _Nonnull)tileState


### PR DESCRIPTION

*Issue #, if available:*
#126 
*Description of changes:*
Make remaining video tile state accessible from video tile added callback.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
