### PR TITLE
Check if video view is nil before binding

### DIFF
--- a/ios/RNDemo/NativeMobileSDKBridge.m
+++ b/ios/RNDemo/NativeMobileSDKBridge.m
@@ -131,7 +131,11 @@ RCT_EXPORT_METHOD(bindVideoView:(NSNumber * _Nonnull)viewIdentifier tileId:(NSNu
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     UIView* view = [self.bridge.uiManager viewForReactTag:viewIdentifier];
-    [meetingSession.audioVideo bindVideoViewWithVideoView:(DefaultVideoRenderView*)view tileId:[tileId integerValue]];
+    if(view != nil) {
+      [meetingSession.audioVideo bindVideoViewWithVideoView:(DefaultVideoRenderView*)view tileId:[tileId integerValue]];
+    } else {
+      [logger errorWithMsg:@"Failed to bind video view"];
+    }
   });
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Check if video view is nil before binding, in order to prevent crashes.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
