### PR TITLE
Route from meeting page to login page when both audio and video sessi…

### DIFF
--- a/android/app/src/main/java/com/amazonaws/services/chime/rndemo/MeetingObservers.kt
+++ b/android/app/src/main/java/com/amazonaws/services/chime/rndemo/MeetingObservers.kt
@@ -27,7 +27,8 @@ import com.amazonaws.services.chime.sdk.meetings.utils.logger.LogLevel
 
 class MeetingObservers(private val eventEmitter: RNEventEmitter) : RealtimeObserver, VideoTileObserver, AudioVideoObserver, DataMessageObserver {
     private val logger = ConsoleLogger(LogLevel.DEBUG)
-
+    private var isAudioSessionStopped = true
+    private var isVideoSessionStopped = true
     companion object {
         private const val TAG = "MeetingObservers"
     }
@@ -109,6 +110,8 @@ class MeetingObservers(private val eventEmitter: RNEventEmitter) : RealtimeObser
         logger.info(TAG, "Received event for audio session started. Reconnecting: $reconnecting")
 
         if (!reconnecting) {
+            isAudioSessionStopped = false
+            isVideoSessionStopped = false
             eventEmitter.sendReactNativeEvent(RNEventEmitter.RN_EVENT_MEETING_START, null)
         }
     }
@@ -119,6 +122,8 @@ class MeetingObservers(private val eventEmitter: RNEventEmitter) : RealtimeObser
 
     override fun onAudioSessionStopped(sessionStatus: MeetingSessionStatus) {
         // Not implemented for demo purposes
+        isAudioSessionStopped = true
+        emitRnMeetingEndEventIfNeeded()
     }
 
     override fun onCameraSendAvailabilityUpdated(available: Boolean) {
@@ -143,6 +148,8 @@ class MeetingObservers(private val eventEmitter: RNEventEmitter) : RealtimeObser
 
     override fun onVideoSessionStopped(sessionStatus: MeetingSessionStatus) {
         // Not implemented for demo purposes
+        isVideoSessionStopped = true
+        emitRnMeetingEndEventIfNeeded()
     }
 
     override fun onDataMessageReceived(dataMessage: DataMessage) {
@@ -155,5 +162,11 @@ class MeetingObservers(private val eventEmitter: RNEventEmitter) : RealtimeObser
 
     override fun onRemoteVideoSourceUnavailable(sources: List<RemoteVideoSource>) {
         // Not implemented for demo purposes
+    }
+
+    private fun emitRnMeetingEndEventIfNeeded() {
+        if(isAudioSessionStopped && isVideoSessionStopped) {
+            eventEmitter.sendReactNativeEvent(RNEventEmitter.RN_EVENT_MEETING_END, null)
+        }
     }
 }

--- a/android/app/src/main/java/com/amazonaws/services/chime/rndemo/NativeMobileSDKBridge.kt
+++ b/android/app/src/main/java/com/amazonaws/services/chime/rndemo/NativeMobileSDKBridge.kt
@@ -154,7 +154,6 @@ class NativeMobileSDKBridge(
         logger.info(TAG, "Called stopMeeting")
 
         meetingSession?.audioVideo?.stop()
-        eventEmitter.sendReactNativeEvent(RN_EVENT_MEETING_END, null)
     }
 
     @ReactMethod


### PR DESCRIPTION
*Issue #, if available:*
 - On Android, if user presses start button very fast after meeting is ended, the demo will route to meeting page, and crash when pressing camera or end meeting buttons.

*Description of changes:*
 - Route the screen to login page when both audio/video sessions are stopped, instead of in `NativeMobileSDKBridge.stopMeeting()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
