### PR TITLE
Fix boost checksum

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,3 +1,21 @@
+# Refs: https://github.com/boostorg/boost/issues/996
+def find_and_replace_boost_url
+  pod_spec = "../node_modules/react-native/third-party-podspecs/boost.podspec"
+  puts "Debug: Starting boost URL replacement"
+  if File.exist?(pod_spec)
+    puts "Debug: Found boost.podspec"
+    spec_content = File.read(pod_spec)
+    spec_content.gsub!(
+      'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
+      'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2'
+    )
+    File.write(pod_spec, spec_content)
+    puts "Debug: Updated boost.podspec"
+  end
+end
+
+find_and_replace_boost_url
+
 platform :ios, '12.4'
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'


### PR DESCRIPTION
I faced the below issue when I run `pod install` in `ios` directory and come up with this recommened patch. Please find the reference at the bottom.

```sh
pod install --verbose
-> Installing boost (1.76.0)
 > Http download
   $ /usr/bin/curl -f -L -o /var/folders/ww/s8zph_vx1_j6tj9wn6xp1yd80000gq/T/d20250701-29855-h6bz1j/file.tbz
   https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 --create-dirs --netrc-optional --retry 2 -A 'CocoaPods/1.16.2 cocoapods-downloader/2.1'
     % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                    Dload  Upload   Total   Spent    Left  Speed
   100   138  100   138    0     0    154      0 --:--:-- --:--:-- --:--:--   154
   100 11533  100 11533    0     0   6666      0  0:00:01  0:00:01 --:--:-- 31258

[!] Error installing boost
Verification checksum was incorrect, expected xxx, got xxx
```

Refs: https://github.com/boostorg/boost/issues/996
